### PR TITLE
fix(api): input validation and token security hardening

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.schemas.scans import (
     ScanCreate,
     ScanResponse,
 )
+from app.session import store_token
 from app.worker import task_deep_scan, task_quick_scan
 
 app = FastAPI(title="Redact", version="0.1.0")
@@ -35,9 +36,13 @@ async def health():
 
 @app.post("/scans", response_model=ScanResponse, status_code=201)
 async def create_scan(body: ScanCreate, db: Session = Depends(get_db)):
-    # Use a placeholder session_id (real session handling comes with auth)
     raw_session = str(uuid.uuid4())
     session_id = hashlib.sha256(raw_session.encode()).hexdigest()
+
+    # Store token in Redis session — never pass through Celery
+    token = body.token or os.environ.get("GITHUB_TOKEN")
+    if token:
+        store_token(session_id, token)
 
     scan = Scan(
         id=uuid.uuid4(),
@@ -55,39 +60,12 @@ async def create_scan(body: ScanCreate, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(scan)
 
+    # Queue task — worker reads token from Redis session if needed
     if body.scan_type == "quick":
-        task_quick_scan.delay(str(scan.id), body.target_name, body.token)
-    elif body.scan_type == "deep":
-        if body.target_type == "repo":
-            # Single repo — construct directly
-            repo_dicts = [
-                {
-                    "full_name": body.target_name,
-                    "clone_url": f"https://github.com/{body.target_name}.git",
-                }
-            ]
-        else:
-            # Org/user — list repos via adapter
-            from app.adapters.github import GitHubAdapter
-
-            adapter = GitHubAdapter(
-                token=body.token or os.environ.get("GITHUB_TOKEN")
-            )
-            try:
-                repos = await adapter.list_repos(body.target_name)
-            finally:
-                await adapter.close()
-
-            if not repos:
-                raise HTTPException(status_code=404, detail="No public repos found")
-
-            repo_dicts = [
-                {"full_name": r.full_name, "clone_url": r.clone_url} for r in repos
-            ]
-        task_deep_scan.delay(str(scan.id), repo_dicts)
+        task_quick_scan.delay(str(scan.id), body.target_name, session_id)
     else:
-        raise HTTPException(
-            status_code=400, detail="scan_type must be 'quick' or 'deep'"
+        task_deep_scan.delay(
+            str(scan.id), body.target_name, body.target_type, session_id
         )
 
     return scan

--- a/backend/app/schemas/scans.py
+++ b/backend/app/schemas/scans.py
@@ -1,15 +1,44 @@
+import re
 import uuid
 from datetime import datetime
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+# GitHub org/user: alphanumeric + hyphens, 1-39 chars, no leading/trailing hyphen
+_GH_OWNER_RE = re.compile(r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$")
+# GitHub repo name: alphanumeric, hyphens, underscores, dots, 1-100 chars
+_GH_REPO_RE = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
 
 
 class ScanCreate(BaseModel):
-    platform: str = "github"
-    target_type: str  # 'org', 'user', 'repo'
+    platform: Literal["github"] = "github"
+    target_type: Literal["org", "user", "repo"]
     target_name: str
-    scan_type: str  # 'quick', 'deep'
+    scan_type: Literal["quick", "deep"]
     token: str | None = None
+
+    @field_validator("target_name")
+    @classmethod
+    def validate_target_name(cls, v: str, info: object) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("target_name must not be empty")
+        # Access target_type from already-validated data
+        values = info.data if hasattr(info, "data") else {}  # type: ignore[union-attr]
+        target_type = values.get("target_type", "")
+        if target_type == "repo":
+            if "/" not in v:
+                raise ValueError("repo target_name must be in 'owner/repo' format")
+            owner, repo = v.split("/", 1)
+            if not _GH_OWNER_RE.match(owner):
+                raise ValueError(f"invalid GitHub owner: {owner}")
+            if not _GH_REPO_RE.match(repo):
+                raise ValueError(f"invalid GitHub repo name: {repo}")
+        else:
+            if not _GH_OWNER_RE.match(v):
+                raise ValueError(f"invalid GitHub org/user name: {v}")
+        return v
 
 
 class ScanResponse(BaseModel):

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -1,0 +1,25 @@
+import os
+
+import redis
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379/0")
+SESSION_TTL = 7200  # 2 hours
+
+
+def _get_redis() -> redis.Redis:
+    return redis.Redis.from_url(REDIS_URL, decode_responses=True)
+
+
+def store_token(session_id: str, token: str) -> None:
+    """Store a GitHub PAT in Redis under session:{session_id} with TTL."""
+    r = _get_redis()
+    r.setex(f"session:{session_id}", SESSION_TTL, token)
+    r.close()
+
+
+def get_token(session_id: str) -> str | None:
+    """Retrieve a GitHub PAT from Redis session. Returns None if expired/missing."""
+    r = _get_redis()
+    val = r.get(f"session:{session_id}")
+    r.close()
+    return val

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -44,11 +44,13 @@ def _publish_progress(scan_id: str, data: dict) -> None:
 
 
 @app.task(name="redact.quick_scan")
-def task_quick_scan(scan_id: str, target: str, token: str | None = None) -> None:
+def task_quick_scan(scan_id: str, target: str, session_id: str) -> None:
     """Run quick scan (GitHub Search API) as background task."""
     import asyncio
 
-    token = token or os.environ.get("GITHUB_TOKEN")
+    from app.session import get_token
+
+    token = get_token(session_id) or os.environ.get("GITHUB_TOKEN")
     db = SessionLocal()
     try:
         asyncio.run(run_quick_scan(uuid.UUID(scan_id), target, token, db))
@@ -62,10 +64,57 @@ def task_quick_scan(scan_id: str, target: str, token: str | None = None) -> None
 
 
 @app.task(name="redact.deep_scan")
-def task_deep_scan(scan_id: str, repos: list[dict], timeout: int = 300) -> None:
+def task_deep_scan(
+    scan_id: str, target_name: str, target_type: str, session_id: str,
+    timeout: int = 300,
+) -> None:
     """Run deep scan (clone + TruffleHog) as background task."""
+    import asyncio
+
+    from app.adapters.github import GitHubAdapter
+    from app.session import get_token
+
+    from app.models.models import Scan
+
     db = SessionLocal()
     try:
+        # Mark running before repo listing so UI shows progress
+        scan = db.query(Scan).filter(Scan.id == uuid.UUID(scan_id)).first()
+        if scan:
+            scan.status = "running"
+            db.commit()
+
+        # Build repo list — moved here from route handler
+        if target_type == "repo":
+            repos = [
+                {
+                    "full_name": target_name,
+                    "clone_url": f"https://github.com/{target_name}.git",
+                }
+            ]
+        else:
+            token = get_token(session_id) or os.environ.get("GITHUB_TOKEN")
+            adapter = GitHubAdapter(token=token)
+
+            async def _list() -> list[dict]:
+                try:
+                    result = await adapter.list_repos(target_name)
+                finally:
+                    await adapter.close()
+                return [
+                    {"full_name": r.full_name, "clone_url": r.clone_url}
+                    for r in result
+                ]
+
+            repos = asyncio.run(_list())
+
+        if not repos:
+            scan = db.query(Scan).filter(Scan.id == uuid.UUID(scan_id)).first()
+            if scan:
+                scan.status = "failed"
+                db.commit()
+            _publish_progress(scan_id, {"event": "failed", "error": "No public repos found"})
+            return
 
         def on_progress(data: dict) -> None:
             _publish_progress(scan_id, data)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 from app.models.models import Finding
 
@@ -10,8 +10,9 @@ def test_health(client):
     assert resp.json() == {"status": "ok"}
 
 
+@patch("app.main.store_token")
 @patch("app.main.task_quick_scan")
-def test_create_quick_scan(mock_task, client):
+def test_create_quick_scan(mock_task, mock_store, client):
     mock_task.delay = lambda *a, **kw: None
     resp = client.post(
         "/scans",
@@ -29,26 +30,16 @@ def test_create_quick_scan(mock_task, client):
     assert data["platform"] == "github"
 
 
-@patch("app.adapters.github.GitHubAdapter")
+@patch("app.main.store_token")
 @patch("app.main.task_deep_scan")
-def test_create_deep_scan(mock_task, mock_adapter_cls, client):
-    from app.adapters.base import Repo
+def test_create_deep_scan(mock_task, mock_store, client):
+    """Deep scan for org no longer calls GitHub API in route — just queues task."""
+    called_args = {}
 
-    mock_task.delay = lambda *a, **kw: None
-    mock_adapter = AsyncMock()
-    mock_adapter.list_repos.return_value = [
-        Repo(
-            name="repo1",
-            full_name="test-org/repo1",
-            clone_url="https://github.com/test-org/repo1.git",
-            default_branch="main",
-            size_kb=100,
-            is_private=False,
-            last_pushed_at="2026-01-01T00:00:00Z",
-        )
-    ]
-    mock_adapter_cls.return_value = mock_adapter
+    def capture_delay(*args, **kwargs):
+        called_args["args"] = args
 
+    mock_task.delay = capture_delay
     resp = client.post(
         "/scans",
         json={
@@ -59,10 +50,75 @@ def test_create_deep_scan(mock_task, mock_adapter_cls, client):
     )
     assert resp.status_code == 201
     assert resp.json()["scan_type"] == "deep"
+    # Verify task receives (scan_id, target_name, target_type, session_id)
+    args = called_args["args"]
+    assert args[1] == "test-org"
+    assert args[2] == "org"
+    assert len(args[3]) == 64  # SHA256 session_id
 
 
+@patch("app.main.store_token")
+@patch("app.main.task_deep_scan")
+def test_create_deep_scan_repo(mock_task, mock_store, client):
+    """Deep scan for single repo passes target_type='repo'."""
+    called_args = {}
+    mock_task.delay = lambda *a, **kw: called_args.update(args=a)
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "repo",
+            "target_name": "owner/repo",
+            "scan_type": "deep",
+        },
+    )
+    assert resp.status_code == 201
+    assert called_args["args"][2] == "repo"
+
+
+@patch("app.main.store_token")
 @patch("app.main.task_quick_scan")
-def test_get_scan(mock_task, client):
+def test_token_not_in_celery_args(mock_task, mock_store, client):
+    """Token must never be serialized into Celery task arguments."""
+    called_args = {}
+    mock_task.delay = lambda *a, **kw: called_args.update(args=a)
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "org",
+            "target_name": "test-org",
+            "scan_type": "quick",
+            "token": "ghp_supersecrettoken123",
+        },
+    )
+    assert resp.status_code == 201
+    # Args should be (scan_id, target, session_id) — no token
+    args = called_args["args"]
+    for arg in args:
+        assert "ghp_supersecrettoken123" not in str(arg)
+
+
+@patch("app.main.store_token")
+@patch("app.main.task_quick_scan")
+def test_token_stored_in_session(mock_task, mock_store, client):
+    """Token should be stored via store_token when provided."""
+    mock_task.delay = lambda *a, **kw: None
+    client.post(
+        "/scans",
+        json={
+            "target_type": "org",
+            "target_name": "test-org",
+            "scan_type": "quick",
+            "token": "ghp_testtoken",
+        },
+    )
+    mock_store.assert_called_once()
+    _, token = mock_store.call_args[0]
+    assert token == "ghp_testtoken"
+
+
+@patch("app.main.store_token")
+@patch("app.main.task_quick_scan")
+def test_get_scan(mock_task, mock_store, client):
     mock_task.delay = lambda *a, **kw: None
     resp = client.post(
         "/scans",
@@ -85,8 +141,9 @@ def test_get_scan_not_found(client):
     assert resp.status_code == 404
 
 
+@patch("app.main.store_token")
 @patch("app.main.task_quick_scan")
-def test_get_findings_empty(mock_task, client):
+def test_get_findings_empty(mock_task, mock_store, client):
     mock_task.delay = lambda *a, **kw: None
     resp = client.post(
         "/scans",
@@ -105,8 +162,9 @@ def test_get_findings_empty(mock_task, client):
     assert data["total"] == 0
 
 
+@patch("app.main.store_token")
 @patch("app.main.task_quick_scan")
-def test_get_findings_with_data(mock_task, client, db):
+def test_get_findings_with_data(mock_task, mock_store, client, db):
     mock_task.delay = lambda *a, **kw: None
     resp = client.post(
         "/scans",
@@ -118,7 +176,6 @@ def test_get_findings_with_data(mock_task, client, db):
     )
     scan_id = resp.json()["id"]
 
-    # Insert a finding directly
     finding = Finding(
         id=uuid.uuid4(),
         scan_id=uuid.UUID(scan_id),
@@ -143,6 +200,9 @@ def test_get_findings_with_data(mock_task, client, db):
     assert data["findings"][0]["severity"] == "critical"
 
 
+# --- Input validation tests ---
+
+
 def test_invalid_scan_type(client):
     resp = client.post(
         "/scans",
@@ -152,4 +212,66 @@ def test_invalid_scan_type(client):
             "scan_type": "invalid",
         },
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 422
+
+
+def test_invalid_target_type(client):
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "invalid",
+            "target_name": "test-org",
+            "scan_type": "quick",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_invalid_target_name_special_chars(client):
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "org",
+            "target_name": "test org; rm -rf /",
+            "scan_type": "quick",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_invalid_repo_format(client):
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "repo",
+            "target_name": "no-slash-here",
+            "scan_type": "deep",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_valid_repo_format(client):
+    with patch("app.main.store_token"), patch("app.main.task_deep_scan") as mock_task:
+        mock_task.delay = lambda *a, **kw: None
+        resp = client.post(
+            "/scans",
+            json={
+                "target_type": "repo",
+                "target_name": "owner/my-repo.js",
+                "scan_type": "deep",
+            },
+        )
+        assert resp.status_code == 201
+
+
+def test_empty_target_name(client):
+    resp = client.post(
+        "/scans",
+        json={
+            "target_type": "org",
+            "target_name": "   ",
+            "scan_type": "quick",
+        },
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Three security hardening fixes since the last merge:

- Add input validation to scan creation schemas
- Remove GitHub token from Celery task queue (session-only, never passed to workers)
- Update API tests for token session handling and input validation