### PR TITLE
Fix TruffleHog: remove --only-verified (minimal fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run TruffleHog on our own repo
         run: |
           docker run --rm -v "$PWD:/repo" trufflesecurity/trufflehog:latest \
-            git file:///repo --only-verified --fail
+            git file:///repo --fail
 
   trivy-fs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Removed --only-verified flag (policy compliance)
- Restored git mode with full history scan
- Removed artifact / jq / extra steps per review feedback