### PR TITLE
docs: add setup script and getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,14 @@ Browser → Nginx → FastAPI Backend → Celery Worker (TruffleHog) → Postgre
 ## Quick Start
 
 ```bash
-# 1. Clone
 git clone https://github.com/liamadale/redact.git
 cd redact
-
-# 2. Configure environment
-cp .env.example .env
-# Edit .env — at minimum set SESSION_SECRET_KEY to a random value
-
-# 3. Start all services
-docker compose up --build
-
-# 4. Open
-# App:     http://localhost:80
-# API:     http://localhost:8000/health
-# API docs: http://localhost:8000/docs
+./setup.sh
 ```
+
+The setup script checks prerequisites, creates your `.env`, builds all containers, and opens the dashboard at [http://localhost:3000](http://localhost:3000).
+
+For a detailed walkthrough — including running your first scan, understanding findings, and generating compliance reports — see the **[Getting Started Guide](docs/getting-started.md)**.
 
 ## Environment Variables
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,226 @@
+# Getting Started with Redact
+
+This guide walks you through setting up a local Redact instance and running your first secrets scan.
+
+## Prerequisites
+
+| Tool | Minimum Version | Install |
+|---|---|---|
+| Docker | 20.10+ | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
+| Docker Compose | v2+ (bundled with Docker Desktop) | Included with Docker Desktop |
+| Git | 2.x | [git-scm.com](https://git-scm.com/) |
+
+Verify your setup:
+
+```bash
+docker --version
+docker compose version
+git --version
+```
+
+### Hardware
+
+- ~4 GB free RAM (PostgreSQL, Redis, backend, worker, and frontend all run simultaneously)
+- ~3 GB disk for container images on first build
+
+### Ports
+
+Redact binds to these local ports:
+
+| Port | Service |
+|---|---|
+| 80 | Nginx (reverse proxy) |
+| 3000 | Frontend (React dev) |
+| 8000 | Backend API (FastAPI) |
+| 5432 | PostgreSQL |
+| 6379 | Redis |
+
+Make sure none of these are in use before starting.
+
+## Setup
+
+### Option A: Automated (recommended)
+
+```bash
+git clone https://github.com/liamadale/redact.git
+cd redact
+./setup.sh
+```
+
+The script checks prerequisites, creates your `.env`, builds all containers, and waits for the backend to become healthy. When it finishes you'll see the dashboard URL.
+
+### Option B: Manual
+
+```bash
+# Clone
+git clone https://github.com/liamadale/redact.git
+cd redact
+
+# Create environment file
+cp .env.example .env
+# Generate a random session secret (or set your own)
+sed -i "s/change-me-to-a-random-string/$(openssl rand -hex 32)/" .env
+
+# Build and start
+docker compose up -d --build
+```
+
+The backend container automatically waits for PostgreSQL and runs database migrations on startup — no manual migration step needed.
+
+### Verify
+
+```bash
+# Backend health check
+curl http://localhost:8000/health
+# → {"status":"ok"}
+
+# Open the dashboard
+open http://localhost:3000    # macOS
+xdg-open http://localhost:3000  # Linux
+```
+
+## Your First Scan
+
+### 1. Open the dashboard
+
+Navigate to [http://localhost:3000](http://localhost:3000). You'll see the landing page with a scan form.
+
+### 2. Choose a target
+
+- **Org / User** — scans all public repos under a GitHub organization or user account (e.g., `trufflesecurity`)
+- **Repo** — scans a single public repo in `owner/repo` format (e.g., `trufflesecurity/test_keys`)
+
+> **Note:** Redact only scans public repositories. Private repos are rejected before any scan is queued.
+
+### 3. Choose a scan type
+
+| Type | What it does | Speed |
+|---|---|---|
+| **Quick Scan** | Uses the GitHub Search API to find files matching known secret patterns. No clone required. | Fast (seconds) |
+| **Deep Scan** | Clones the repo and runs TruffleHog across the full git history, all branches. Detects secrets that were committed and later removed. | Slower (depends on repo size) |
+
+For your first scan, try a **Quick Scan** on `trufflesecurity` — it's the TruffleHog maintainer's org and has test repos with intentionally seeded secrets.
+
+### 4. Monitor progress
+
+After clicking **Run**, you're taken to the scan view. Progress updates stream in real-time via SSE:
+
+- **Queued** → scan is waiting for a worker
+- **Running** → repos are being scanned (progress bar shows repos completed)
+- **Completed** → all repos processed
+
+### 5. Review findings
+
+Once complete, findings are listed with:
+
+- **Severity** — critical (verified secrets), high, medium, low
+- **Secret type** — AWS key, GitHub token, private key, etc.
+- **File path and commit** — where the secret was found
+- **Redacted preview** — first 4 characters + masked remainder
+
+Click any finding to see its detail page, including NIST 800-53 and DISA STIG compliance mappings.
+
+### 6. Generate a report
+
+From the scan view, click **Report** to access:
+
+- **PDF report** — compliance-mapped findings with NIST/STIG controls, suitable for auditors
+- **JSON export** — machine-readable findings for integration with other tools
+
+Reports can be filtered by severity and repository.
+
+## GitHub Token (Optional)
+
+Without a token, GitHub API rate limits are low (10 requests/min unauthenticated). For org scans with many repos, add a personal access token:
+
+1. Create a token at [github.com/settings/tokens](https://github.com/settings/tokens) — no scopes needed (public repo access only)
+2. Add it to your `.env`:
+   ```
+   GITHUB_TOKEN=ghp_your_token_here
+   ```
+3. Restart the backend: `docker compose restart backend`
+
+The token is used for GitHub API calls only (repo listing, search). It is never passed to `git clone`, never stored in the database, and never sent to Celery workers.
+
+## Configuration
+
+All settings are in `.env`. Key options:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MAX_CONCURRENT_SCANS` | `3` | Number of repos scanned in parallel |
+| `MAX_REPO_SIZE_MB` | `500` | Skip repos larger than this |
+| `SCAN_TIMEOUT_SECONDS` | `300` | Per-repo timeout for deep scans |
+
+See [`.env.example`](../.env.example) for the full list.
+
+## Common Commands
+
+```bash
+# View logs (all services)
+docker compose logs -f
+
+# View logs for a specific service
+docker compose logs -f worker
+
+# Stop all services
+docker compose down
+
+# Stop and remove all data (database, volumes)
+docker compose down -v
+
+# Rebuild after code changes
+docker compose up -d --build
+```
+
+## Troubleshooting
+
+### "Port X is already in use"
+
+Another process is using one of the required ports. Find it:
+
+```bash
+lsof -i :8000   # replace with the conflicting port
+```
+
+Stop the conflicting process, or change the port mapping in `docker-compose.yml`.
+
+### Backend never becomes healthy
+
+Check the backend logs:
+
+```bash
+docker compose logs backend
+```
+
+Common causes:
+- **PostgreSQL not ready** — the backend entrypoint retries automatically, but if the DB container failed to start, check `docker compose logs db`
+- **Migration error** — if the schema is out of date, the backend runs `alembic upgrade head` on startup. Check for migration conflicts in the logs.
+
+### Scan stuck in "queued"
+
+The worker may not be running:
+
+```bash
+docker compose logs worker
+```
+
+If the worker crashed, restart it: `docker compose restart worker`
+
+### "Private repositories are not supported"
+
+Redact only scans public repositories. If you entered a private repo or an org that has no public repos, you'll see this error. This is by design.
+
+### Deep scan is slow
+
+Deep scans clone the full git history. Large repos with long histories take longer. You can:
+- Reduce `SCAN_TIMEOUT_SECONDS` to skip repos that take too long
+- Use Quick Scan first to triage, then Deep Scan specific repos
+
+### Container build fails
+
+First build downloads base images and installs dependencies (~3 GB). Ensure you have enough disk space and a stable internet connection. If a build fails partway:
+
+```bash
+docker compose build --no-cache
+```

--- a/docs/self-scan-findings.md
+++ b/docs/self-scan-findings.md
@@ -1,0 +1,56 @@
+# Redact Self-Scan Findings
+
+> Redact scanning its own repository — eating our own dog food.
+
+## Date
+
+2026-04-25
+
+## Summary
+
+A deep scan of `liamadale/redact` produced **6 critical findings**, all Postgres connection strings verified as live by TruffleHog.
+
+## Findings
+
+| # | File | Commit | Severity | Verified |
+|---|---|---|---|---|
+| 1 | `backend/app/database.py:7` | f24359b | Critical | ✅ Live |
+| 2 | `backend/alembic/env.py:15` | f24359b | Critical | ✅ Live |
+| 3 | `backend/alembic.ini:89` | f24359b | Critical | ✅ Live |
+| 4 | `.env.example:2` | 2943f7d | Critical | ✅ Live |
+| 5 | `README.md:76` | 2943f7d | Critical | ✅ Live |
+| 6 | `docs/implementation-plan.md:612` | 81df56f | Critical | ✅ Live |
+
+All six findings are the same credential: the default Docker Compose Postgres connection string `postgresql://redact:redact@db:5432/redact`.
+
+## Analysis
+
+These are **true positives** — TruffleHog correctly identified database credentials in source code and verified they are active (the Postgres container was running with these credentials at scan time).
+
+However, the **risk is negligible**:
+
+- The credentials are the default local Docker Compose dev database (`redact`/`redact`)
+- They only work inside the Docker network (`db` hostname) — not reachable externally
+- `.env.example`, `README.md`, and `implementation-plan.md` are documentation — they intentionally show the connection string as example config
+- `database.py` and `alembic/env.py` use the value as a fallback default when the `DATABASE_URL` environment variable is not set
+- No production deployment exists — this is a local-only dev tool
+
+## Compliance Controls Triggered
+
+- **NIST 800-53 IA-5** — Authenticator Management
+- **NIST 800-53 CM-6** — Configuration Settings
+- **NIST 800-53 AU-2** — Audit Events
+- **DISA STIG V-222642** — Application must not contain embedded authentication data
+
+## Remediation Assessment
+
+| Finding | Recommended Action |
+|---|---|
+| `database.py`, `alembic/env.py` | Could remove hardcoded fallback and require `DATABASE_URL` env var. Low priority — only affects local dev. |
+| `alembic.ini` | Could template the URL via env var. Low priority. |
+| `.env.example` | Intentional — this is the example config file. No action needed. |
+| `README.md`, `implementation-plan.md` | Documentation references. No action needed. |
+
+## Takeaway
+
+This is a useful demonstration that Redact works as intended — it found real credentials in its own codebase, verified them as live, and mapped them to the correct compliance controls. The fact that these are low-risk dev defaults doesn't change the fact that the tool correctly flagged them. In a production codebase, the same pattern (hardcoded DB credentials with a fallback default) would be a real vulnerability.

--- a/frontend/src/pages/ScanView.tsx
+++ b/frontend/src/pages/ScanView.tsx
@@ -287,6 +287,7 @@ export function ScanView() {
     queryKey: ["hits", id],
     queryFn: () => api.getHits(id!),
     enabled: !!id && scan?.scan_type === "quick",
+    refetchInterval: scan?.status === "running" ? 3000 : false,
   });
 
   useEffect(() => {

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[✓]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $1"; }
+error() { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+
+echo ""
+echo "  ██████╗ ███████╗██████╗  █████╗  ██████╗████████╗"
+echo "  ██╔══██╗██╔════╝██╔══██╗██╔══██╗██╔════╝╚══██╔══╝"
+echo "  ██████╔╝█████╗  ██║  ██║███████║██║        ██║   "
+echo "  ██╔══██╗██╔══╝  ██║  ██║██╔══██║██║        ██║   "
+echo "  ██║  ██║███████╗██████╔╝██║  ██║╚██████╗   ██║   "
+echo "  ╚═╝  ╚═╝╚══════╝╚═════╝ ╚═╝  ╚═╝ ╚═════╝   ╚═╝   "
+echo ""
+
+# --- Prerequisites ---
+command -v docker >/dev/null 2>&1 || error "Docker is not installed. See https://docs.docker.com/get-docker/"
+command -v git >/dev/null 2>&1    || error "Git is not installed."
+
+docker info >/dev/null 2>&1 || error "Docker daemon is not running. Start Docker and try again."
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE="docker compose"
+elif docker-compose version >/dev/null 2>&1; then
+  COMPOSE="docker-compose"
+else
+  error "Docker Compose is not installed."
+fi
+
+info "Prerequisites OK (docker, git, compose)"
+
+# --- Port checks ---
+PORTS=(80 3000 5432 6379 8000)
+for port in "${PORTS[@]}"; do
+  if lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1 || ss -tlnp 2>/dev/null | grep -q ":$port "; then
+    error "Port $port is already in use. Free it and try again."
+  fi
+done
+info "Required ports available (${PORTS[*]})"
+
+# --- .env ---
+if [ ! -f .env ]; then
+  cp .env.example .env
+  SECRET=$(openssl rand -hex 32 2>/dev/null || head -c 64 /dev/urandom | od -An -tx1 | tr -d ' \n')
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/change-me-to-a-random-string/$SECRET/" .env
+  else
+    sed -i "s/change-me-to-a-random-string/$SECRET/" .env
+  fi
+  info "Created .env with generated SESSION_SECRET_KEY"
+else
+  info ".env already exists — skipping"
+fi
+
+# --- Build & start ---
+warn "Building containers (first run may take a few minutes)..."
+$COMPOSE up -d --build
+
+# --- Wait for backend ---
+echo -n "Waiting for backend "
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8000/health >/dev/null 2>&1; then
+    echo ""
+    info "Backend is healthy"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo ""
+    warn "Backend didn't respond in 60s. Check logs: $COMPOSE logs backend"
+  fi
+  echo -n "."
+  sleep 2
+done
+
+echo ""
+info "Redact is running!"
+echo ""
+echo "  Dashboard:  http://localhost:3000"
+echo "  API:        http://localhost:8000"
+echo "  API docs:   http://localhost:8000/docs"
+echo ""
+echo "  Stop:       $COMPOSE down"
+echo "  Logs:       $COMPOSE logs -f"
+echo ""


### PR DESCRIPTION
Adds a one-command setup experience and comprehensive getting started documentation.

## Changes

- **setup.sh** — checks prerequisites (Docker, Compose, git), verifies port availability, generates `.env` from `.env.example` with a random session secret, builds and starts all containers, and waits for the backend health check
- **docs/getting-started.md** — full walkthrough covering prerequisites, setup, first scan, GitHub token config, and troubleshooting
- **README.md** — updated Quick Start section to reference `setup.sh` and link to the getting started guide