### PR TITLE
Added triage view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,7 +46,7 @@ function usePageLabel(): string | null {
   if (matchPath("/metrics/:id", pathname)) return "Metrics";
   if (matchPath("/scans/:id/report", pathname)) return "Report";
   if (matchPath("/scans/:id/findings/:findingId", pathname)) return "Finding";
-  if (matchPath("/scans/:id/repos", pathname)) return "Repo Search";
+  if (matchPath("/scans/:id/repos", pathname)) return "Triage";
   if (matchPath("/scans/:id", pathname)) return "Scan";
   return null;
 }
@@ -105,7 +105,7 @@ function Nav() {
                   <NavLink to={`/scans/${scanId}/report`} label="Report" />
                 </>
               )}
-              <NavLink to={`/scans/${scanId}/repos`} label="Repo Search" />
+              <NavLink to={`/scans/${scanId}/repos`} label="Triage" />
               <span className="w-px h-4 bg-tokyo-border mx-1" />
             </>
           )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ const Dashboard = lazy(() => import("./pages/Dashboard").then((m) => ({ default:
 const FindingDetail = lazy(() => import("./pages/FindingDetail").then((m) => ({ default: m.FindingDetail })));
 const Metrics = lazy(() => import("./pages/Metrics").then((m) => ({ default: m.Metrics })));
 const Report = lazy(() => import("./pages/Report").then((m) => ({ default: m.Report })));
+const RepoSearchResults = lazy(() => import("./pages/RepoSearchResults").then((m) => ({ default: m.RepoSearchResults })));
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { staleTime: 10_000 } },
@@ -26,6 +27,7 @@ function useScanIdFromRoute(): string | null {
   const { pathname } = useLocation();
   const patterns = [
     "/scans/:id",
+    "/scans/:id/repos",
     "/scans/:id/findings/:findingId",
     "/scans/:id/report",
     "/dashboard/:id",
@@ -44,6 +46,7 @@ function usePageLabel(): string | null {
   if (matchPath("/metrics/:id", pathname)) return "Metrics";
   if (matchPath("/scans/:id/report", pathname)) return "Report";
   if (matchPath("/scans/:id/findings/:findingId", pathname)) return "Finding";
+  if (matchPath("/scans/:id/repos", pathname)) return "Repo Search";
   if (matchPath("/scans/:id", pathname)) return "Scan";
   return null;
 }
@@ -92,12 +95,17 @@ function Nav() {
 
         {/* Right: context actions */}
         <div className="flex items-center gap-2 shrink-0">
-          {scan && scanId && scan.scan_type === "deep" && (
+          {scan && scanId && (
             <>
-              <NavLink to={`/scans/${scanId}`} label="Scan" />
-              <NavLink to={`/dashboard/${scanId}`} label="Dashboard" />
-              <NavLink to={`/metrics/${scanId}`} label="Metrics" />
-              <NavLink to={`/scans/${scanId}/report`} label="Report" />
+              {scan.scan_type === "deep" && (
+                <>
+                  <NavLink to={`/scans/${scanId}`} label="Scan" />
+                  <NavLink to={`/dashboard/${scanId}`} label="Dashboard" />
+                  <NavLink to={`/metrics/${scanId}`} label="Metrics" />
+                  <NavLink to={`/scans/${scanId}/report`} label="Report" />
+                </>
+              )}
+              <NavLink to={`/scans/${scanId}/repos`} label="Repo Search" />
               <span className="w-px h-4 bg-tokyo-border mx-1" />
             </>
           )}
@@ -140,6 +148,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Landing />} />
             <Route path="/scans/:id" element={<ScanView />} />
+            <Route path="/scans/:scanId/repos" element={<RepoSearchResults />} />
             <Route path="/scans/:scanId/findings/:findingId" element={<FindingDetail />} />
             <Route path="/scans/:scanId/report" element={<Report />} />
             <Route path="/dashboard/:id" element={<Dashboard />} />

--- a/frontend/src/pages/RepoSearchResults.tsx
+++ b/frontend/src/pages/RepoSearchResults.tsx
@@ -190,7 +190,7 @@ function RepoSearchResults() {
             )}
             <Link
               to={`/scans/${scanId}`}
-              className="inline-flex items-center justify-center rounded-md border border-tokyo-border bg-tokyo-bg-highlight px-4 py-2 text-sm font-semibold text-tokyo-comment hover:text-tokyo-fg"
+              className="inline-flex items-center justify-center rounded-md border border-tokyo-border bg-tokyo-bg-highlight px-4 py-2 text-sm font-semibold text-tokyo-fg hover:bg-tokyo-blue/15"
             >
               Back to scan
             </Link>
@@ -220,7 +220,7 @@ function RepoSearchResults() {
             {repoSummaries.map((repo) => {
               const isSelected = selectedRepos.includes(repo.repo);
               return (
-                <div key={repo.repo} className="group rounded-3xl border border-tokyo-border bg-tokyo-bg-highlight p-5 transition hover:border-tokyo-blue/40">
+                <div key={repo.repo} className="group rounded-lg border border-tokyo-border bg-tokyo-bg-highlight p-5 transition hover:border-tokyo-blue/40">
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <div className="flex items-center gap-2">  

--- a/frontend/src/pages/RepoSearchResults.tsx
+++ b/frontend/src/pages/RepoSearchResults.tsx
@@ -173,7 +173,7 @@ function RepoSearchResults() {
             <p className="text-xs font-mono uppercase tracking-widest text-tokyo-comment">{title}</p>
             <h1 className="mt-2 text-3xl font-bold text-tokyo-fg">{scan.target_name}</h1>
             <p className="mt-2 text-sm text-tokyo-comment">
-              {scan.scan_type === "quick" ? "High-level repository search results from the quick scan." : "Repository findings grouped by repo."}
+              {scan.scan_type === "quick" ? "High-level repository search results from the quick scan." : "Findings grouped by repository."}
             </p>
           </div>
 
@@ -223,18 +223,32 @@ function RepoSearchResults() {
                 <div key={repo.repo} className="group rounded-3xl border border-tokyo-border bg-tokyo-bg-highlight p-5 transition hover:border-tokyo-blue/40">
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2">  
+                        
+                        {/* Card selector */}
                         <input
                           type="checkbox"
                           checked={isSelected}
                           onChange={() => handleToggleRepo(repo.repo)}
-                          className="h-4 w-4 rounded border-tokyo-border bg-tokyo-bg text-tokyo-blue focus:ring-tokyo-blue"
+                          className="cursor-pointer"
                         />
-                        <h2 className="text-base font-semibold text-tokyo-fg break-words">{repo.repo}</h2>
+
+                        {/* Repo name */}
+                        <h2 className="text-base font-semibold text-tokyo-fg break-words">
+                          {repo.repo}
+                        </h2>
                       </div>
                       <p className="mt-2 text-[11px] text-tokyo-comment">{isQuick ? `${repo.totalHits ?? 0} search hits` : `${repo.totalFindings ?? 0} findings`}</p>
                     </div>
-                    <div className="shrink-0 rounded-full border border-tokyo-border bg-tokyo-bg px-3 py-1 text-[10px] font-mono uppercase text-tokyo-comment">
+
+                    {/* Maximum finding severity */}
+                    <div
+                      className={`shrink-0 bg-tokyo-blue rounded border border-tokyo-border px-3 py-1 text-[10px] font-mono uppercase ${
+                        isQuick
+                          ? "bg-tokyo-bg text-tokyo-comment"
+                          : `${SEVERITY_CONFIG[repo.maxSeverity ?? "low"].bg} ${SEVERITY_CONFIG[repo.maxSeverity ?? "low"].text}`
+                      }`}
+                    >
                       {isQuick ? "SEARCH" : repo.maxSeverity?.toUpperCase() ?? "LOW"}
                     </div>
                   </div>
@@ -262,13 +276,13 @@ function RepoSearchResults() {
                       type="button"
                       onClick={() => deepScanMutation.mutate(repo.repo)}
                       disabled={isDeepScanLoading}
-                      className="w-full rounded-md border border-tokyo-blue/40 bg-tokyo-blue/10 px-4 py-2 text-sm font-semibold text-tokyo-blue transition hover:bg-tokyo-blue/15 disabled:opacity-50 sm:w-auto"
+                      className="w-full rounded-md border border-tokyo-blue/40 bg-tokyo-blue/10 px-4 py-2 text-sm font-semibold text-tokyo-blue cursor-pointer transition hover:bg-tokyo-blue/15 disabled:opacity-50 sm:w-auto"
                     >
                       {isDeepScanLoading ? "Queuing..." : "Deep scan repo"}
                     </button>
                     <Link
                       to={`/scans/${scanId}`}
-                      className="w-full text-center rounded-md border border-tokyo-border bg-tokyo-bg px-4 py-2 text-sm text-tokyo-comment transition hover:text-tokyo-fg sm:w-auto"
+                      className="w-full text-center rounded-md border border-tokyo-border bg-tokyo-blue/10 px-4 py-2 text-sm text-tokyo-fg sm:w-auto transition hover:bg-tokyo-blue/15"
                     >
                       View scan
                     </Link>

--- a/frontend/src/pages/RepoSearchResults.tsx
+++ b/frontend/src/pages/RepoSearchResults.tsx
@@ -163,14 +163,12 @@ function RepoSearchResults() {
 
   const isQuick = scan.scan_type === "quick";
   const isDeep = scan.scan_type === "deep";
-  const title = isQuick ? "Repository Search Results" : "Repository Summary";
 
   return (
     <div className="min-h-screen bg-tokyo-bg px-6 py-8">
       <div className="max-w-7xl mx-auto">
         <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div>
-            <p className="text-xs font-mono uppercase tracking-widest text-tokyo-comment">{title}</p>
             <h1 className="mt-2 text-3xl font-bold text-tokyo-fg">{scan.target_name}</h1>
             <p className="mt-2 text-sm text-tokyo-comment">
               {scan.scan_type === "quick" ? "High-level repository search results from the quick scan." : "Findings grouped by repository."}

--- a/frontend/src/pages/RepoSearchResults.tsx
+++ b/frontend/src/pages/RepoSearchResults.tsx
@@ -225,18 +225,17 @@ function RepoSearchResults() {
                     <div>
                       <div className="flex items-center gap-2">  
                         
-                        {/* Card selector */}
+                        <label className="flex items-center gap-2 cursor-pointer">
                         <input
                           type="checkbox"
                           checked={isSelected}
                           onChange={() => handleToggleRepo(repo.repo)}
                           className="cursor-pointer"
                         />
-
-                        {/* Repo name */}
                         <h2 className="text-base font-semibold text-tokyo-fg break-words">
                           {repo.repo}
                         </h2>
+                      </label>
                       </div>
                       <p className="mt-2 text-[11px] text-tokyo-comment">{isQuick ? `${repo.totalHits ?? 0} search hits` : `${repo.totalFindings ?? 0} findings`}</p>
                     </div>

--- a/frontend/src/pages/RepoSearchResults.tsx
+++ b/frontend/src/pages/RepoSearchResults.tsx
@@ -1,0 +1,286 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+import type { Finding, Scan } from "../lib/types";
+
+const SEVERITY_ORDER = ["critical", "high", "medium", "low"] as const;
+
+const SEVERITY_CONFIG: Record<NonNullable<Finding["severity"]>, { label: string; text: string; bg: string }> = {
+  critical: { label: "CRIT", text: "text-tokyo-red", bg: "bg-tokyo-red/10" },
+  high: { label: "HIGH", text: "text-tokyo-orange", bg: "bg-tokyo-orange/10" },
+  medium: { label: "MED", text: "text-tokyo-yellow", bg: "bg-tokyo-yellow/10" },
+  low: { label: "LOW", text: "text-tokyo-comment", bg: "bg-white/5" },
+};
+
+type RepoSummary = {
+  repo: string;
+  totalCount: number;
+  totalHits?: number;
+  totalFindings?: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  maxSeverity?: Finding["severity"];
+};
+
+function RepoSearchResults() {
+  const { scanId } = useParams<{ scanId: string }>();
+  const navigate = useNavigate();
+  const [selectedRepos, setSelectedRepos] = useState<string[]>([]);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  const { data: scan } = useQuery<Scan>({
+    queryKey: ["scan", scanId],
+    queryFn: () => api.getScan(scanId!),
+    enabled: !!scanId,
+  });
+
+  const { data: findings } = useQuery({
+    queryKey: ["findings", scanId],
+    queryFn: () => api.getFindings(scanId!, 0, 200),
+    enabled: !!scanId && scan?.scan_type === "deep",
+  });
+
+  const { data: hits } = useQuery({
+    queryKey: ["hits", scanId],
+    queryFn: () => api.getHits(scanId!),
+    enabled: !!scanId && scan?.scan_type === "quick",
+  });
+
+  const repoSummaries = useMemo<RepoSummary[]>(() => {
+    if (!scan) return [];
+
+    const map = new Map<string, RepoSummary>();
+
+    if (scan.scan_type === "deep") {
+      const allFindings = findings?.findings ?? [];
+      for (const finding of allFindings) {
+        const repo = finding.repo_name;
+        if (!map.has(repo)) {
+          map.set(repo, {
+            repo,
+            totalCount: 0,
+            totalFindings: 0,
+            critical: 0,
+            high: 0,
+            medium: 0,
+            low: 0,
+          });
+        }
+        const entry = map.get(repo)!;
+        entry.totalCount += 1;
+        entry.totalFindings = (entry.totalFindings ?? 0) + 1;
+        entry[finding.severity] += 1;
+
+        const candidate = finding.severity;
+        if (!entry.maxSeverity || SEVERITY_ORDER.indexOf(candidate) < SEVERITY_ORDER.indexOf(entry.maxSeverity)) {
+          entry.maxSeverity = candidate;
+        }
+      }
+    }
+
+    if (scan.scan_type === "quick") {
+      const allHits = hits?.hits ?? [];
+      for (const hit of allHits) {
+        const repo = hit.repo_name;
+        if (!map.has(repo)) {
+          map.set(repo, {
+            repo,
+            totalCount: 0,
+            totalHits: 0,
+            critical: 0,
+            high: 0,
+            medium: 0,
+            low: 0,
+          });
+        }
+        const entry = map.get(repo)!;
+        entry.totalCount += 1;
+        entry.totalHits = (entry.totalHits ?? 0) + 1;
+      }
+    }
+
+    return Array.from(map.values()).sort((a, b) => {
+      if (b.totalCount !== a.totalCount) return b.totalCount - a.totalCount;
+      return a.repo.localeCompare(b.repo);
+    });
+  }, [scan, findings, hits]);
+
+  const deepScanMutation = useMutation({
+    mutationFn: (repoName: string) =>
+      api.createScan({
+        target_type: "repo",
+        target_name: repoName,
+        scan_type: "deep",
+      }),
+    onSuccess: (scan) => {
+      navigate(`/scans/${scan.id}`);
+    },
+    onError: (error: any) => {
+      setStatusMessage(error?.message ?? "Unable to queue deep scan.");
+    },
+  });
+
+  const isDeepScanLoading = deepScanMutation.status === "pending";
+
+  const handleToggleRepo = (repo: string) => {
+    setSelectedRepos((prev) =>
+      prev.includes(repo) ? prev.filter((name) => name !== repo) : [...prev, repo]
+    );
+  };
+
+  const handleBulkDeepScan = async () => {
+    if (!selectedRepos.length) return;
+    setStatusMessage(null);
+    setBulkLoading(true);
+
+    const results = await Promise.allSettled(
+      selectedRepos.map((repo) =>
+        api.createScan({ target_type: "repo", target_name: repo, scan_type: "deep" })
+      )
+    );
+
+    setBulkLoading(false);
+    const successCount = results.filter((result) => result.status === "fulfilled").length;
+    const failedCount = results.length - successCount;
+    setSelectedRepos([]);
+    setStatusMessage(
+      `${successCount} deep scan${successCount === 1 ? "" : "s"} queued${failedCount ? `, ${failedCount} failed` : ""}.`
+    );
+  };
+
+  if (!scanId || !scan) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-8">
+        <p className="text-tokyo-comment mb-4">No scan selected.</p>
+        <Link to="/" className="text-tokyo-blue hover:underline">Start a new scan</Link>
+      </div>
+    );
+  }
+
+  const isQuick = scan.scan_type === "quick";
+  const isDeep = scan.scan_type === "deep";
+  const title = isQuick ? "Repository Search Results" : "Repository Summary";
+
+  return (
+    <div className="min-h-screen bg-tokyo-bg px-6 py-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-xs font-mono uppercase tracking-widest text-tokyo-comment">{title}</p>
+            <h1 className="mt-2 text-3xl font-bold text-tokyo-fg">{scan.target_name}</h1>
+            <p className="mt-2 text-sm text-tokyo-comment">
+              {scan.scan_type === "quick" ? "High-level repository search results from the quick scan." : "Repository findings grouped by repo."}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            {selectedRepos.length > 0 && (
+              <button
+                type="button"
+                onClick={handleBulkDeepScan}
+                disabled={bulkLoading}
+                className="inline-flex items-center justify-center rounded-md border border-tokyo-blue/40 bg-tokyo-blue/10 px-4 py-2 text-sm font-semibold text-tokyo-blue hover:bg-tokyo-blue/15 disabled:opacity-50"
+              >
+                {bulkLoading ? "Queuing..." : `Deep scan ${selectedRepos.length} selected`}
+              </button>
+            )}
+            <Link
+              to={`/scans/${scanId}`}
+              className="inline-flex items-center justify-center rounded-md border border-tokyo-border bg-tokyo-bg-highlight px-4 py-2 text-sm font-semibold text-tokyo-comment hover:text-tokyo-fg"
+            >
+              Back to scan
+            </Link>
+          </div>
+        </div>
+
+        <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-tokyo-comment">
+          <span>{repoSummaries.length} repositories</span>
+          <span className="h-4 w-px bg-tokyo-border" />
+          <span>{isQuick ? `${hits?.total ?? 0} total hits` : `${findings?.total ?? 0} total findings`}</span>
+          <span className="h-4 w-px bg-tokyo-border" />
+          <span>Scan status: {scan.status.toUpperCase()}</span>
+        </div>
+
+        {statusMessage && (
+          <div className="mb-4 rounded-lg border border-tokyo-blue/30 bg-tokyo-blue/5 px-4 py-3 text-sm text-tokyo-fg">
+            {statusMessage}
+          </div>
+        )}
+
+        {repoSummaries.length === 0 ? (
+          <div className="rounded-3xl border border-tokyo-border bg-tokyo-bg-highlight p-10 text-center text-sm text-tokyo-comment">
+            {scan.status === "running" ? "Scanning repositories..." : "No repositories found yet."}
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {repoSummaries.map((repo) => {
+              const isSelected = selectedRepos.includes(repo.repo);
+              return (
+                <div key={repo.repo} className="group rounded-3xl border border-tokyo-border bg-tokyo-bg-highlight p-5 transition hover:border-tokyo-blue/40">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => handleToggleRepo(repo.repo)}
+                          className="h-4 w-4 rounded border-tokyo-border bg-tokyo-bg text-tokyo-blue focus:ring-tokyo-blue"
+                        />
+                        <h2 className="text-base font-semibold text-tokyo-fg break-words">{repo.repo}</h2>
+                      </div>
+                      <p className="mt-2 text-[11px] text-tokyo-comment">{isQuick ? `${repo.totalHits ?? 0} search hits` : `${repo.totalFindings ?? 0} findings`}</p>
+                    </div>
+                    <div className="shrink-0 rounded-full border border-tokyo-border bg-tokyo-bg px-3 py-1 text-[10px] font-mono uppercase text-tokyo-comment">
+                      {isQuick ? "SEARCH" : repo.maxSeverity?.toUpperCase() ?? "LOW"}
+                    </div>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {isDeep && SEVERITY_ORDER.map((level) =>
+                      repo[level] > 0 ? (
+                        <span
+                          key={level}
+                          className={`text-[10px] font-mono font-bold px-2.5 py-1 rounded ${SEVERITY_CONFIG[level].bg} ${SEVERITY_CONFIG[level].text}`}
+                        >
+                          {repo[level]} {SEVERITY_CONFIG[level].label}
+                        </span>
+                      ) : null
+                    )}
+                    {isQuick && repo.totalHits && (
+                      <span className="text-[10px] font-mono font-bold px-2.5 py-1 rounded bg-tokyo-blue/10 text-tokyo-blue">
+                        {repo.totalHits} hits
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <button
+                      type="button"
+                      onClick={() => deepScanMutation.mutate(repo.repo)}
+                      disabled={isDeepScanLoading}
+                      className="w-full rounded-md border border-tokyo-blue/40 bg-tokyo-blue/10 px-4 py-2 text-sm font-semibold text-tokyo-blue transition hover:bg-tokyo-blue/15 disabled:opacity-50 sm:w-auto"
+                    >
+                      {isDeepScanLoading ? "Queuing..." : "Deep scan repo"}
+                    </button>
+                    <Link
+                      to={`/scans/${scanId}`}
+                      className="w-full text-center rounded-md border border-tokyo-border bg-tokyo-bg px-4 py-2 text-sm text-tokyo-comment transition hover:text-tokyo-fg sm:w-auto"
+                    >
+                      View scan
+                    </Link>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export { RepoSearchResults };


### PR DESCRIPTION
Issue #8 completed

Added:
- A new route and page that displays high-level findings by repository
  - The page uses a card/grid layout, and shows finding counts and severity badges for each repository with findings
  - The UI allows users to trigger individual or bulk Deep Scans
- Note: I called the tab "Triage" to align with the docs, but go ahead and rename it if you have something better in mind
  - I couldn't think of a better name that didn't sound too similar in purpose to the other existing tabs

Known Issues:
- Quick scans show 0/0 repositories scanned for me, and as a result always have empty triage views
  - However, the triage view appears to work, as cards appear and function properly on deep scans with findings across multiple repositories